### PR TITLE
Fix/26 input elem popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.9](https://github.com/ethan-far/ngx-window/compare/v0.0.7...v0.0.9) (2023-12-31)
+
+* Fixed bug #26 - `<input>` elements' popups are not displayed when inside an `<ngx-window>`
+
 ## [0.0.7](https://github.com/ethan-far/ngx-window/compare/v0.0.6...v0.0.7) (2023-08-25)
 
 * Angular 16 support

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Latest version available for each version of Angular
 
 | ngx-window-component | Angular |
 | -------------------- | ------- |
+| 0.0.7                | 16.x    |
 | 0.0.5                | 13.x    |
 
 # Install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ngx-window-demo",
-    "version": "0.0.7",
+    "version": "0.0.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ngx-window-demo",
-            "version": "0.0.7",
+            "version": "0.0.9",
             "dependencies": {
                 "@angular/animations": "^16.2.2",
                 "@angular/cdk": "^16.2.1",
@@ -296,61 +296,6 @@
             "resolved": "https://registry.npmjs.org/typed-assert/-/typed-assert-1.0.9.tgz",
             "integrity": "sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==",
             "dev": true
-        },
-        "node_modules/@angular-devkit/build-angular/node_modules/vite": {
-            "version": "4.4.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
-            "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
-            "dev": true,
-            "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.26",
-                "rollup": "^3.25.2"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            },
-            "peerDependencies": {
-                "@types/node": ">= 14",
-                "less": "*",
-                "lightningcss": "^1.21.0",
-                "sass": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/@angular-devkit/build-angular/node_modules/webpack-subresource-integrity": {
             "version": "5.1.0",
@@ -803,12 +748,12 @@
             "dev": true
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-            "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.10",
+                "@babel/highlight": "^7.23.4",
                 "chalk": "^2.4.2"
             },
             "engines": {
@@ -935,12 +880,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.10",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -1073,22 +1018,36 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-function-name/node_modules/@babel/template": {
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1241,18 +1200,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -1296,12 +1255,12 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-            "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
@@ -1381,9 +1340,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
-            "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -2700,20 +2659,20 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-            "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+            "version": "7.23.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+            "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.23.6",
+                "@babel/types": "^7.23.6",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -2721,13 +2680,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-            "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -5335,9 +5294,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+            "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.0",
@@ -15691,6 +15650,61 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/vite": {
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
+            "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "^0.18.10",
+                "postcss": "^8.4.26",
+                "rollup": "^3.25.2"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            },
+            "peerDependencies": {
+                "@types/node": ">= 14",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -16495,18 +16509,6 @@
                     "integrity": "sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==",
                     "dev": true
                 },
-                "vite": {
-                    "version": "4.4.7",
-                    "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
-                    "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
-                    "dev": true,
-                    "requires": {
-                        "esbuild": "^0.18.10",
-                        "fsevents": "~2.3.2",
-                        "postcss": "^8.4.26",
-                        "rollup": "^3.25.2"
-                    }
-                },
                 "webpack-subresource-integrity": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-5.1.0.tgz",
@@ -16793,12 +16795,12 @@
             "dev": true
         },
         "@babel/code-frame": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-            "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.22.10",
+                "@babel/highlight": "^7.23.4",
                 "chalk": "^2.4.2"
             },
             "dependencies": {
@@ -16898,12 +16900,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.22.10",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -17006,19 +17008,32 @@
             }
         },
         "@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true
         },
         "@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
+            },
+            "dependencies": {
+                "@babel/template": {
+                    "version": "7.22.15",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+                    "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.22.13",
+                        "@babel/parser": "^7.22.15",
+                        "@babel/types": "^7.22.15"
+                    }
+                }
             }
         },
         "@babel/helper-hoist-variables": {
@@ -17126,15 +17141,15 @@
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true
         },
         "@babel/helper-validator-option": {
@@ -17166,12 +17181,12 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-            "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
@@ -17235,9 +17250,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
-            "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
             "dev": true
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -18121,31 +18136,31 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-            "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+            "version": "7.23.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+            "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "debug": "^4.1.0",
+                "@babel/parser": "^7.23.6",
+                "@babel/types": "^7.23.6",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-            "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -20029,9 +20044,9 @@
             "dev": true
         },
         "axios": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
+            "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
             "dev": true,
             "requires": {
                 "follow-redirects": "^1.15.0",
@@ -27611,6 +27626,18 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true
+        },
+        "vite": {
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
+            "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+            "dev": true,
+            "requires": {
+                "esbuild": "^0.18.10",
+                "fsevents": "~2.3.2",
+                "postcss": "^8.4.26",
+                "rollup": "^3.25.2"
+            }
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-window-demo",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "scripts": {
         "ng": "ng",
         "start": "ng serve -o --host 127.0.0.1 --port 4100",

--- a/projects/ngx-window/package.json
+++ b/projects/ngx-window/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-window-component",
   "description": "Lightweight window layer component for Angular",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "homepage": "https://github.com/ethan-far/ngx-window",
   "bugs": {

--- a/projects/ngx-window/src/lib/window.component.html
+++ b/projects/ngx-window/src/lib/window.component.html
@@ -1,6 +1,6 @@
 <ng-template #template>
     <div class="window" [attr.data-window-id]="id" [style.width.px]="width" [style.height.px]="height"
-        [style.top.px]="top" [style.left.px]="left" (click)="onClick($event)">
+        [style.top.px]="top" [style.left.px]="left">
         <ng-content windowContent></ng-content>
     </div>
 </ng-template>

--- a/projects/ngx-window/src/lib/window.component.spec.ts
+++ b/projects/ngx-window/src/lib/window.component.spec.ts
@@ -332,36 +332,6 @@ describe('WindowComponent', () => {
                 expect(divElement.styles['width']).toEqual('123px');
                 expect(divElement.styles['height']).toEqual('456px');
             });
-
-            describe('click handler that', () => {
-
-                let eventMock: any;
-
-                beforeEach(() => {
-                    eventMock = {
-                        stopPropagation: jest.fn(),
-                        preventDefault: jest.fn()
-                    }
-                });
-
-                it('stops the propagation of the event', () => {
-                    fixture.detectChanges();
-
-                    let divElement = element.query(By.css('.window'));
-                    divElement.triggerEventHandler('click', eventMock);
-
-                    expect(eventMock.stopPropagation).toHaveBeenCalled();
-                });
-
-                it('prevents the default of the event', () => {
-                    fixture.detectChanges();
-
-                    let divElement = element.query(By.css('.window'));
-                    divElement.triggerEventHandler('click', eventMock);
-
-                    expect(eventMock.preventDefault).toHaveBeenCalled();
-                });
-            });
         });
     });
 

--- a/projects/ngx-window/src/lib/window.component.ts
+++ b/projects/ngx-window/src/lib/window.component.ts
@@ -94,11 +94,6 @@ export class WindowComponent implements OnInit, AfterContentChecked, OnDestroy {
         }
     }
 
-    onClick(event: MouseEvent) {
-        event.stopPropagation();
-        event.preventDefault();
-    }
-
     open() {
         this.windowService.open(this._id!, this.template);
     }


### PR DESCRIPTION
Bug fix for #26 . 
Removed the click listener that prevented the default click behavior and propagation inside the window. 
I couldn't remember why it was there, probably part of the earlier approach to handling click events to close the windows.
Tested on the demo app, remove it doesn't seem to have any negative effect, but if real life applications prove that it's needed, I shall create a new issue.